### PR TITLE
Pass 'value' instead of 'obj' to serialize_func

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1530,7 +1530,7 @@ class Function(Field):
         self.deserialize_func = deserialize and utils.callable_or_raise(deserialize)
 
     def _serialize(self, value, attr, obj, **kwargs):
-        return self._call_or_raise(self.serialize_func, obj, attr)
+        return self._call_or_raise(self.serialize_func, value, attr)
 
     def _deserialize(self, value, attr, data, **kwargs):
         if self.deserialize_func:


### PR DESCRIPTION
The parameter 'value' should be passed to the function `serialize_func` in `fields.Function` instead of 'obj'.
